### PR TITLE
fix: pin the openai version to 1.65.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         'XBlock',
-        'openai'
+        'openai==1.65.1'
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
## Description
By default when installing this x block `openai` version `0.28.1` is installed. However as per https://github.com/abconlinecourses/chatgpt-xblock/pull/8 we updated the code to work with `openai=1.65.1`. The reason the code is working for us is because we install `ai-coach-xblock` as well which updates the version for `openai` to `1.65.1`

 However currently this xblock will not work unless ai-coach-xblock is also installed after it.